### PR TITLE
add perl to global packages

### DIFF
--- a/setup/docker/fixes.sh
+++ b/setup/docker/fixes.sh
@@ -4,6 +4,3 @@ apt-get -y install libgl1 libgomp1
 
 # pixi global mistakenly points the samtools wrapper to samtools.pl, so we need to revert this change
 #sed -i "s/samtools.pl/samtools/" /root/.pixi/bin/samtools
-
-# install perl modules
-apt-get install --yes perl-modules

--- a/setup/docker/global_packages
+++ b/setup/docker/global_packages
@@ -19,6 +19,7 @@ ldstore
 micromamba
 notebook
 parallel
+perl
 plink
 plink2
 ptpython


### PR DESCRIPTION
We previously had installed `perl-modules` with `apt-get` because we were using the system Perl to run `annovar`.  It turns out that `conda-forge` Perl package has the `Pod::Usage` module and whatever else is needed by `annovar`, so we can just install the `perl` global package and `annovar` should work as is!