### PR TITLE
Use jovyan user

### DIFF
--- a/setup/course_entrypoint.sh
+++ b/setup/course_entrypoint.sh
@@ -30,10 +30,10 @@ find "$repo_dir/contents" -type f -name "*.ipynb" | parallel -j $(nproc) "jupyte
 
 
 # Sync the contents directory
-AWS_ACCESS_KEY_ID=$BUCKET_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$BUCKET_SECRET_KEY aws s3 sync s3://opcenter-bucket-ada686a0-ccdb-11ee-b922-02ebafc2e5cf/tutorial_data /root/handson-tutorials/contents
+AWS_ACCESS_KEY_ID=$BUCKET_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$BUCKET_SECRET_KEY aws s3 sync s3://opcenter-bucket-ada686a0-ccdb-11ee-b922-02ebafc2e5cf/tutorial_data /home/jovyan/handson-tutorials/contents
 
 # Sync the annovar software
-(AWS_ACCESS_KEY_ID=$BUCKET_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$BUCKET_SECRET_KEY aws s3 sync s3://opcenter-bucket-ada686a0-ccdb-11ee-b922-02ebafc2e5cf/annovar_software/ /usr/local/bin --exclude "*" --include "*.pl" && chmod +x /usr/local/bin/*.pl) || (echo -e "\033[1;31mWarning: Cannot install ANNOVAR program due to license restriction. Exercise involving ANNOVAR annotations will not work unless you manually install ANNOVAR to the /usr/local/bin folder of the tutorials.\033[0m" && true)
+(AWS_ACCESS_KEY_ID=$BUCKET_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$BUCKET_SECRET_KEY aws s3 sync s3://opcenter-bucket-ada686a0-ccdb-11ee-b922-02ebafc2e5cf/annovar_software/ /home/jovyan/.pixi/bin --exclude "*" --include "*.pl" && chmod +x /home/jovyan/.pixi/bin/*.pl) || (echo -e "\033[1;31mWarning: Cannot install ANNOVAR program due to license restriction. Exercise involving ANNOVAR annotations will not work unless you manually install ANNOVAR to the /home/jovyan/.pixi/bin folder of the tutorials.\033[0m" && true)
 
 # Fix plink.multivariate
-mv /root/handson-tutorials/contents/archive/plink.multivariate /usr/local/bin && chmod +x /usr/local/bin/plink.multivariate
+mv /home/jovyan/handson-tutorials/contents/archive/plink.multivariate /home/jovyan/.pixi/bin && chmod +x /home/jovyan/.pixi/bin/plink.multivariate

--- a/setup/docker/Dockerfile
+++ b/setup/docker/Dockerfile
@@ -1,7 +1,12 @@
 FROM ghcr.io/prefix-dev/pixi:latest
 USER root
 # For security reasons, SSL certificates and timezone database must be installed by host package manager
-RUN apt-get update && apt-get -y install ca-certificates tzdata curl unzip tree
+RUN apt-get update && apt-get -y install ca-certificates tzdata libgl1 libgomp1
+# Use bash as default shell instead of dash
+RUN ln -sf /bin/bash /bin/sh  
+
+RUN useradd --no-log-init --create-home --shell /bin/bash --uid 1000 --no-user-group jovyan
+USER jovyan
 
 # Copy over configs and environments
 COPY r_libs.yml /tmp
@@ -10,22 +15,19 @@ COPY global_packages /tmp
 COPY init.sh /tmp
 COPY fixes.sh /tmp
 
-RUN mkdir -p /root/.config/pixi && \
-    echo 'default_channels = ["dnachun", "conda-forge", "bioconda"]' > /root/.config/pixi/config.toml
-
-# Use bash as default shell instead of dash
-RUN ln -sf /bin/bash /bin/sh  
+RUN mkdir -p /home/jovyan/.config/pixi && \
+    echo 'default_channels = ["dnachun", "conda-forge", "bioconda"]' > /home/jovyan/.config/pixi/config.toml
 
 # Install global packages with pixi
 RUN pixi global install $(tr '\n' ' ' < /tmp/global_packages)
-ENV PATH="/root/.pixi/bin:${PATH}"
+ENV PATH="/home/jovyan/.pixi/bin:${PATH}"
 
 # Install R and Python libraries with micromamba (will replace with pixi in future)
 RUN micromamba config prepend channels nodefaults 
 RUN micromamba config prepend channels bioconda
 RUN micromamba config prepend channels conda-forge
 RUN micromamba config prepend channels dnachun
-RUN micromamba shell init --shell=bash /root/micromamba
+RUN micromamba shell init --shell=bash /home/jovyan/micromamba
 RUN micromamba env create --yes --quiet --file /tmp/r_libs.yml;
 RUN micromamba env create --yes --quiet --file /tmp/python_libs.yml;
 RUN micromamba clean --all --yes
@@ -39,6 +41,7 @@ RUN bash /tmp/fixes.sh
 # Clean up
 RUN rm -rf /tmp/*
 
-COPY entrypoint.sh /root/entrypoint.sh
-RUN chmod +x /root/entrypoint.sh
-CMD ["/root/entrypoint.sh"]
+COPY entrypoint.sh /home/jovyan/entrypoint.sh
+RUN chmod +x /home/jovyan/entrypoint.sh
+ENV PYDEVD_DISABLE_FILE_VALIDATION=1
+CMD ["/home/jovyan/entrypoint.sh"]

--- a/setup/docker/Dockerfile
+++ b/setup/docker/Dockerfile
@@ -44,4 +44,5 @@ RUN rm -rf /tmp/*
 COPY entrypoint.sh /home/jovyan/entrypoint.sh
 RUN chmod +x /home/jovyan/entrypoint.sh
 ENV PYDEVD_DISABLE_FILE_VALIDATION=1
+WORKDIR /home/jovyan
 CMD ["/home/jovyan/entrypoint.sh"]

--- a/setup/docker/entrypoint.sh
+++ b/setup/docker/entrypoint.sh
@@ -4,5 +4,5 @@ curl -o /tmp/course_entrypoint.sh https://raw.githubusercontent.com/cumc/handson
 chmod +x /tmp/course_entrypoint.sh
 bash /tmp/course_entrypoint.sh
 
-cd /root/handson-tutorials/contents
-PYDEVD_DISABLE_FILE_VALIDATION=1 jupyter-lab
+cd /home/jovyan/handson-tutorials/contents
+jupyter-lab

--- a/setup/docker/fixes.sh
+++ b/setup/docker/fixes.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# r-rgl needs libGL.so.1 provided by the system package manager
-apt-get -y install libgl1 libgomp1
-
 # pixi global mistakenly points the samtools wrapper to samtools.pl, so we need to revert this change
 #sed -i "s/samtools.pl/samtools/" /root/.pixi/bin/samtools

--- a/setup/docker/global_packages
+++ b/setup/docker/global_packages
@@ -3,6 +3,7 @@ bcftools
 bedtools
 bgenix
 cassi
+curl
 ensembl-vep
 fastlmmc
 finemap
@@ -28,3 +29,5 @@ r-base=4.3
 regenie
 sos
 snpsift
+tree
+unzip

--- a/setup/docker/init.sh
+++ b/setup/docker/init.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-set -e
+set -o errexit -o xtrace
 # Only show PYTHONPATH and R_LIBS to specific executables
-sed -i '2i export PYTHONPATH="/root/micromamba/envs/python_libs/lib/python3.12/site-packages"' /root/.pixi/bin/python
-sed -i '2i export PYTHONPATH="/root/micromamba/envs/python_libs/lib/python3.12/site-packages"' /root/.pixi/bin/python3
-sed -i '2i export PYTHONPATH="/root/micromamba/envs/python_libs/lib/python3.12/site-packages"' /root/.pixi/bin/jupyter-lab
-sed -i '2i export PYTHONPATH="/root/micromamba/envs/python_libs/lib/python3.12/site-packages"' /root/.pixi/bin/jupyter-server
-sed -i '2i export PYTHONPATH="/root/micromamba/envs/python_libs/lib/python3.12/site-packages"' /root/.pixi/bin/sos
-echo "unset PYTHONPATH" >> /root/.bashrc
-echo '.libPaths("/root/micromamba/envs/r_libs/lib/R/library")' >> /root/.Rprofile
+export HOME="/home/jovyan"
+sed -i '2i export PYTHONPATH="${HOME}/micromamba/envs/python_libs/lib/python3.12/site-packages"' ${HOME}/.pixi/bin/python
+sed -i '2i export PYTHONPATH="${HOME}/micromamba/envs/python_libs/lib/python3.12/site-packages"' ${HOME}/.pixi/bin/python3
+sed -i '2i export PYTHONPATH="${HOME}/micromamba/envs/python_libs/lib/python3.12/site-packages"' ${HOME}/.pixi/bin/jupyter-lab
+sed -i '2i export PYTHONPATH="${HOME}/micromamba/envs/python_libs/lib/python3.12/site-packages"' ${HOME}/.pixi/bin/jupyter-server
+sed -i '2i export PYTHONPATH="${HOME}/micromamba/envs/python_libs/lib/python3.12/site-packages"' ${HOME}/.pixi/bin/sos
+echo "unset PYTHONPATH" >> ${HOME}/.bashrc
+echo ".libPaths('${HOME}/micromamba/envs/r_libs/lib/R/library')" >> ${HOME}/.Rprofile
 
 # pixi global currently gives it wrappers all lowercase names, so we need to make symlinks for R and Rscript
 if [ ! -e "${HOME}/.pixi/bin/R" ]; then
@@ -19,10 +20,10 @@ if [ ! -e "${HOME}/.pixi/bin/Rscript" ]; then
 fi
 
 # Register Juypter kernels
-find /root/micromamba/envs/python_libs/share/jupyter/kernels/ -maxdepth 1 -mindepth 1 -type d | \
-    xargs -I % jupyter-kernelspec install %
-find /root/micromamba/envs/r_libs/share/jupyter/kernels/ -maxdepth 1 -mindepth 1 -type d | \
-    xargs -I % jupyter-kernelspec install %
+find ${HOME}/micromamba/envs/python_libs/share/jupyter/kernels/ -maxdepth 1 -mindepth 1 -type d | \
+    xargs -I % jupyter-kernelspec install --user %
+find ${HOME}/micromamba/envs/r_libs/share/jupyter/kernels/ -maxdepth 1 -mindepth 1 -type d | \
+    xargs -I % jupyter-kernelspec install --user %
 
 # Jupyter configurations
 mkdir -p $HOME/.jupyter


### PR DESCRIPTION
This PR should allow us to run as the `jovyan` user instead of `root`, which should fix some permissions users.  Additionally:
- I removed `curl`, `unzip` and `tree` from the `apt-get` command and replaced them with `pixi` global packages. We should never use `apt-get` to install things that are available in conda itself, unless they have to be installed by the system package manager.  Strictly following this rule is the only way to guarantee things don't break later.
- I set `PYDEVD_DISABLE_FILE_VALIDATION=1` in the Dockerfile.  This guarantee it is global.
